### PR TITLE
fix: locale

### DIFF
--- a/Languages/ru.js
+++ b/Languages/ru.js
@@ -1,6 +1,6 @@
 ﻿export const Dictionary = {
     orderBy: {
-        label: "последовательность",
+        label: "Сортировать по",
         none: "нет",
     },
     languages: {


### PR DESCRIPTION
Hi! If we use "order" in context "order by field" we should use "Сортировать по"